### PR TITLE
fix: json module not loaded

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import time
+import json
 from pathlib import Path
 import modules.extensions as extensions_module
 from modules import api, chat, shared, training, ui


### PR DESCRIPTION
Fixes NameError: name 'json' is not defined when running main.py

> CUDA SETUP: Loading binary F:\oobabooga-windows\installer_files\env\lib\site-packages\bitsandbytes\libbitsandbytes_cuda117.dll...
> Loading settings from settings.json...
> Traceback (most recent call last):
>   File "F:\oobabooga-windows\text-generation-webui\main.py", line 26, in <module>
>     new_settings = json.loads(open(settings_file, 'r').read())
> NameError: name 'json' is not defined
> Press any key to continue . . .